### PR TITLE
fix diff highlighting in magit

### DIFF
--- a/themes/leuven-light-color-theme.json
+++ b/themes/leuven-light-color-theme.json
@@ -374,9 +374,12 @@
 		},
 		{
 			"name": "Markup: Deletion",
-			"scope": "markup.deleted",
+			"scope": [
+				"markup.deleted",
+				"punctuation.definition.deleted"
+			],
 			"settings": {
-				"foreground": "#000000",
+				"foreground": "#CC3333",
 				"background": "#FEE8E9"
 			}
 		},
@@ -404,9 +407,12 @@
 		},
 		{
 			"name": "Markup: Insertion",
-			"scope": "markup.inserted",
+			"scope": [
+				"markup.inserted",
+				"punctuation.definition.inserted"
+			],
 			"settings": {
-				"foreground": "#000000",
+				"foreground": "#3A993A",
 				"background": "#DDFFDD"
 			}
 		},


### PR DESCRIPTION
"background" isn't supported in VS Code themes, so let's set foreground.

The end result looks like this: 

![image](https://user-images.githubusercontent.com/1711539/224998032-0905b53c-0307-4c93-995f-036ea9cecb88.png)

(there wasn't any highlighting before)

This is for https://marketplace.visualstudio.com/items?itemName=kahole.magit